### PR TITLE
Riotapi account support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Snapshots of all the latest changes are available in my personal nexus repositor
 <dependency>
     <groupId>com.stirante</groupId>
     <artifactId>lol-client-java-api</artifactId>
-    <version>1.2.11-SNAPSHOT</version>
+    <version>1.2.12-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.stirante</groupId>
     <artifactId>lol-client-java-api</artifactId>
-    <version>1.2.11-SNAPSHOT</version>
+    <version>1.2.12-SNAPSHOT</version>
     <name>lol-client-java-api</name>
     <description>Simple library which provides access to internal League of Legends Client API.</description>
     <url>https://github.com/stirante/lol-client-java-api</url>

--- a/src/main/java/generated/LolSummonerSummoner.java
+++ b/src/main/java/generated/LolSummonerSummoner.java
@@ -1,9 +1,14 @@
 package generated;
 
+/**
+ * League Client endpoint `/lol-summoner/v1/current-summoner` response.
+ */
+@SuppressWarnings("unused")
 public class LolSummonerSummoner {
 
 	public Long accountId;
 	public String displayName;
+	public String gameName;
 	public String internalName;
 	public Boolean nameChangeFlag;
 	public Integer percentCompleteForNextLevel;
@@ -13,6 +18,7 @@ public class LolSummonerSummoner {
 	public LolSummonerSummonerRerollPoints rerollPoints;
 	public Long summonerId;
 	public Integer summonerLevel;
+	public String tagLine;
 	public Boolean unnamed;
 	public Long xpSinceLastLevel;
 	public Long xpUntilNextLevel;


### PR DESCRIPTION
Deviating from origin. Adding support for RIOT API Account information.
[This](https://github.com/stirante/lol-client-java-api/pull/40) will surpass this PR but we need to include it now.